### PR TITLE
RS-22478: Escape node and title tooltip

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: D3 JavaScript Network Graphs from R
 Description: Creates 'D3' 'JavaScript' network, tree, dendrogram, and Sankey
     graphs from 'R'.
-Version: 0.5.0
+Version: 0.5.1
 Date: 2017-06-18
 Authors@R: c(
     person("J.J.", "Allaire", role = "aut"),

--- a/inst/htmlwidgets/lib/sankeyNetworkDefinition.js
+++ b/inst/htmlwidgets/lib/sankeyNetworkDefinition.js
@@ -1,3 +1,16 @@
+// RS-22478: node/link names are user-supplied data and are written into the
+// tooltips via .html() on an xhtml:body (an HTML parsing context inside the
+// foreignObject), so escape them to prevent stored XSS. The visible node label
+// uses .text() and does not need escaping.
+function htmlEscape(s) {
+    return String(s)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
 const sankeyNetworkDefinition = {
 
     name: "sankeyNetwork",
@@ -168,8 +181,8 @@ const sankeyNetworkDefinition = {
         link.append("title")
             .append("foreignObject")
             .append("xhtml:body")
-            .html(function(d) { return "<pre>" + d.source.name + " \u2192 " + d.target.name +
-                "\n" + format(d.value) + " " + options.units + "</pre>"; });
+            .html(function(d) { return "<pre>" + htmlEscape(d.source.name) + " \u2192 " + htmlEscape(d.target.name) +
+                "\n" + format(d.value) + " " + htmlEscape(options.units) + "</pre>"; });
 
         node.append("rect")
             .attr("height", function(d) { return d.dy; })
@@ -183,8 +196,8 @@ const sankeyNetworkDefinition = {
             .append("foreignObject")
             .append("xhtml:body")
             .attr("class", "node-tooltip")
-            .html(function(d) { return "<pre>" + d.name + "\n" + format(d.value) + 
-                " " + options.units + "</pre>"; });
+            .html(function(d) { return "<pre>" + htmlEscape(d.name) + "\n" + format(d.value) +
+                " " + htmlEscape(options.units) + "</pre>"; });
 
         node.append("text")
             .attr("x", -6)


### PR DESCRIPTION
Fix XSS vulnerability in Sankey diagram. The fix is here rather than flipPlots because the names are used in both the label and the tooltip so escaping the names in flipPlot to fix the tooltip would affect the label.